### PR TITLE
[solutions] same translation for "mapped types"

### DIFF
--- a/uk/easy-pick.md
+++ b/uk/easy-pick.md
@@ -31,14 +31,14 @@ const todo: TodoPreview = {
 
 ## Розв'язок
 
-Для цієї задачі нам потрібні типи пошуку (Lookup Types) та порівняльні типи (Mapped Types).
+Для цієї задачі нам потрібні типи пошуку (Lookup Types) та типи співставлення (Mapped Types).
 
 Типи пошуку дозволяють нам отримати тип з іншого типу за іменем.
 Схоже на отримання значення з об'єкта за ключем.
 
 Порівняльні типи дозволяють перетворити властивості типу в новий тип.
 
-Ви можете прочитати більше про них і зрозуміти як вони працюють на сайті TypeScript: [типи пошуку (lookup types)](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-1.html#keyof-and-lookup-types) і [порівняльні типи (mapped types)](https://www.typescriptlang.org/docs/handbook/advanced-types.html#mapped-types).
+Ви можете прочитати більше про них і зрозуміти як вони працюють на сайті TypeScript: [типи пошуку (lookup types)](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-1.html#keyof-and-lookup-types) і [типи співставлення](https://www.typescriptlang.org/docs/handbook/advanced-types.html#mapped-types).
 
 Тепер, знаючи про типи пошуку та порівняльні типи, як реалізувати необхідний тип?
 
@@ -57,5 +57,5 @@ type MyPick<T, K extends keyof T> = { [P in K]: T[P] }
 ## Посилання
 
 - [Типи пошуку](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-1.html#keyof-and-lookup-types)
-- [Порівняльні типи](https://www.typescriptlang.org/docs/handbook/advanced-types.html#mapped-types)
+- [Типи співставлення](https://www.typescriptlang.org/docs/handbook/advanced-types.html#mapped-types)
 - [Індексні типи](https://www.typescriptlang.org/docs/handbook/advanced-types.html#index-types)

--- a/uk/easy-tuple-to-object.md
+++ b/uk/easy-tuple-to-object.md
@@ -33,5 +33,5 @@ type TupleToObject<T extends readonly any[]> = { [K in T[number]]: K }
 
 ## Посилання
 
-- [Типи зіставлення](https://www.typescriptlang.org/docs/handbook/advanced-types.html#mapped-types)
+- [Типи співставлення](https://www.typescriptlang.org/docs/handbook/advanced-types.html#mapped-types)
 - [Індексні типи](https://www.typescriptlang.org/docs/handbook/advanced-types.html#index-types)

--- a/uk/medium-omit.md
+++ b/uk/medium-omit.md
@@ -28,14 +28,14 @@ const todo: TodoPreview = {
 ## Розв'язок
 
 `Omit<T, K>` приймає об'єкт `T` і список ключів в `K`, які треба виключити з об'єкта.
-Очевидно, що для вирішення цього завдання ми використаємо [типи співставлення (mapped types)](https://www.typescriptlang.org/docs/handbook/advanced-types.html#mapped-types).
+Очевидно, що для вирішення цього завдання ми використаємо [типи співставлення](https://www.typescriptlang.org/docs/handbook/advanced-types.html#mapped-types).
 
 ```typescript
 type MyOmit<T, K> = { [P in keyof T]: T[P] }
 ```
 
 Залишається відфільтрувати властивості, які необхідно залишити в об'єкті.
-Для цього використаємо [перепризначення ключів в типах співставлення (mapped types)](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-1.html#key-remapping-in-mapped-types):
+Для цього використаємо [перепризначення ключів в типах співставлення](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-1.html#key-remapping-in-mapped-types):
 
 ```typescript
 type MyOmit<T, K> = { [P in keyof T as P extends K ? never : P]: T[P] }
@@ -46,7 +46,7 @@ type MyOmit<T, K> = { [P in keyof T as P extends K ? never : P]: T[P] }
 
 ## Посилання
 
-- [Типи співставлення (mapped types)](https://www.typescriptlang.org/docs/handbook/advanced-types.html#mapped-types)
+- [Типи співставлення](https://www.typescriptlang.org/docs/handbook/advanced-types.html#mapped-types)
 - [Типи пошуку/індексні типи](https://www.typescriptlang.org/docs/handbook/advanced-types.html#index-types)
 - [Умовні типи](https://www.typescriptlang.org/docs/handbook/advanced-types.html#conditional-types)
-- [Перепризначення ключів в типах співставлення (mapped types)](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-1.html#key-remapping-in-mapped-types)
+- [Перепризначення ключів в типах співставлення](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-1.html#key-remapping-in-mapped-types)

--- a/uk/medium-promise-all.md
+++ b/uk/medium-promise-all.md
@@ -70,7 +70,7 @@ declare function PromiseAll<T extends unknown[]>(values: readonly [...T]): Promi
 ## Посилання
 
 - [Варіативні типи](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-0.html#variadic-tuple-types)
-- [Типи співставлення (mapped types)](https://www.typescriptlang.org/docs/handbook/advanced-types.html#mapped-types)
+- [Типи співставлення](https://www.typescriptlang.org/docs/handbook/advanced-types.html#mapped-types)
 - [Типи пошуку/індексні типи](https://www.typescriptlang.org/docs/handbook/advanced-types.html#index-types)
 - [Умовні типи](https://www.typescriptlang.org/docs/handbook/advanced-types.html#conditional-types)
 - [Виведення типів в умовних типах](https://www.typescriptlang.org/docs/handbook/advanced-types.html#type-inference-in-conditional-types)

--- a/uk/medium-readonly-2.md
+++ b/uk/medium-readonly-2.md
@@ -72,6 +72,6 @@ type MyReadonly2<T, K extends keyof T = keyof T> = T & { readonly [P in K]: T[P]
 ## Посилання
 
 - [Типи перетину](https://www.typescriptlang.org/docs/handbook/unions-and-intersections.html#intersection-types)
-- [Порівняльні типи](https://www.typescriptlang.org/docs/handbook/advanced-types.html#mapped-types)
+- [Типи співставлення](https://www.typescriptlang.org/docs/handbook/advanced-types.html#mapped-types)
 - [Типи пошуку/індексні типи](https://www.typescriptlang.org/docs/handbook/advanced-types.html#index-types)
 - [Використання типів-параметрів в обмеженнях дженериків](https://www.typescriptlang.org/docs/handbook/generics.html#using-type-parameters-in-generic-constraints)


### PR DESCRIPTION
@ghaiklor @bdvorianov в різних челенджах по різному були перекладені `mapped types`: `порівняльні типи`, `типи співставлення`, `типи зіставлення`

як на мене `типи співставлення` більше підходить, перейменував всі однаково

## Checklist

- [x] Make sure that you are opening the PR with a single solution (one solution per PR)
- [x] The solution must have at least several references for the readers to dive in depth
