### PR TITLE
update en/easy-tuple-length 

### DIFF
--- a/en/easy-tuple-length.md
+++ b/en/easy-tuple-length.md
@@ -36,15 +36,16 @@ JavaScript. We can do the same in types as well:
 type Length<T extends any> = T["length"];
 ```
 
-But going that way we will get the compilation error “Type 'length' cannot be
-used to index type 'T'.”. So we need to give a hint to TypeScript and tell that
-our input type parameter has this property:
+But going that way we will get the compilation error `Type 'length' cannot be
+used to index type 'T'.`. We could try to give a hint to TypeScript and tell that
+our input type parameter has the `length` property:
 
 ```ts
 type Length<T extends { length: number }> = T["length"];
 ```
 
-An alternative solution:
+However, in this case T encompasses both arrays and strings. Instead, check that T is an array
+with:
 
 ```ts
 type Length<T extends readonly any[]> = T["length"];


### PR DESCRIPTION
# Challenge easy-tuple-length 

Small change to account for the test case `Length<"hello world">` which one of the solutions allows for. Since we're just looking for the length of arrays, we shouldn't allow this.

## Checklist

- [x] Make sure that you are opening the PR with a single solution (one solution per PR)
- [x] The solution must have at least several references for the readers to dive in depth
